### PR TITLE
fix(htaccess): serve index.html for non-file requests

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,7 @@
 RewriteEngine On 
 RewriteCond %{HTTPS} off 
 RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.html [QSA,L]


### PR DESCRIPTION
This pull request includes a small change to the `public/.htaccess` file. The change ensures that all requests are redirected to `index.html` if the requested file or directory does not exist. This is necessary to support client-side routing with `React Router`.

* [`public/.htaccess`](diffhunk://#diff-ba277bbff724255df1f11e1b9441f2690bea9565604563a8c9d5bdebb9681ee4R4-R7): Added conditions to redirect non-existing files and directories to `index.html`