### PR TITLE
feat(chat): add handling for previous messages in PartyChat component

### DIFF
--- a/src/components/Games/PartyChat.jsx
+++ b/src/components/Games/PartyChat.jsx
@@ -36,6 +36,15 @@ function PartyChat({ party }) {
             );
         });
 
+        socketInstance.on("previousMessages", (fetchedMessages) => {
+            setMessages(
+                fetchedMessages.map((msg) => ({
+                    username: msg.user.username,
+                    content: msg.message,
+                }))
+            );
+        });
+
         socketInstance.on("receiveMessage", (newMessage) => {
             console.log("Received message", newMessage);
             setMessages((prevMessages) => [


### PR DESCRIPTION
This pull request includes an update to the `PartyChat` component in the `src/components/Games/PartyChat.jsx` file to handle previously sent messages. The most important change is the addition of a socket event listener to fetch and display previous chat messages when the component is initialized.

* [`src/components/Games/PartyChat.jsx`](diffhunk://#diff-d3708f89b0e6badffb6350e9d478fdc91893a705c292842e2de2a75ddc487cc9R39-R47): Added a new socket event listener for "previousMessages" to fetch and set previous chat messages when the component is initialized.