### PR TITLE
chore(ci/cd): rename Node.js CI workflow to Node.js CI/CD

### DIFF
--- a/.github/workflows/nodejs-ci-cd.yml
+++ b/.github/workflows/nodejs-ci-cd.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Node.js CI/CD
 
 on:
   push:


### PR DESCRIPTION
This pull request includes a small but significant change to the CI/CD workflow configuration file. The change involves renaming the file from `.github/workflows/ci-cd.yml` to `.github/workflows/nodejs-ci-cd.yml` and updating the workflow name to "Node.js CI/CD".

Changes to CI/CD workflow configuration:

* [`.github/workflows/nodejs-ci-cd.yml`](diffhunk://#diff-9fff1086794eb54ee1906723dd519ddc0ca07e381dd89bba43ba65209faa9b27L1-R1): Renamed the file from `.github/workflows/ci-cd.yml` and updated the workflow name to "Node.js CI/CD".