### PR TITLE
feat: add timestamp to messages in PartyChat component

### DIFF
--- a/src/components/Games/PartyChat.jsx
+++ b/src/components/Games/PartyChat.jsx
@@ -42,6 +42,7 @@ function PartyChat({ party }) {
                 fetchedMessages.map((msg) => ({
                     username: msg.user.username,
                     content: msg.message,
+                    timestamp: msg.timestamp,
                 })),
             );
         });
@@ -53,6 +54,7 @@ function PartyChat({ party }) {
                 {
                     username: newMessage.user.username,
                     content: newMessage.message,
+                    timestamp: newMessage.timestamp,
                 },
             ]);
         });
@@ -91,7 +93,16 @@ function PartyChat({ party }) {
             <div>
                 {messages.map((message, index) => (
                     <div key={index}>
-                        <strong>{message.username}</strong>: {message.content}
+                        <strong>{message.username}</strong>: {message.content} -{" "}
+                        {message.timestamp
+                            ? new Date(message.timestamp).toLocaleTimeString(
+                                  "fr-FR",
+                                  {
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                  },
+                              )
+                            : "Invalid time"}
                     </div>
                 ))}
             </div>


### PR DESCRIPTION
This pull request includes changes to the `PartyChat` component in `src/components/Games/PartyChat.jsx` to add and display timestamps for chat messages.

Enhancements to message handling and display:

* Added `timestamp` property to the message objects when fetched from the server.
* Included `timestamp` property in the new message object when a new message is received.
* Updated the message display to show the formatted timestamp next to the message content.