### PR TITLE
fix: update forgot password link to use React Router's Link component

### DIFF
--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -52,9 +52,9 @@ function Login() {
                     <div className="form__group">
                         <div className="form__label-container">
                             <label htmlFor="password">Mot de passe</label>
-                            <a className="form__forgot-password" href="#">
+                            <Link className="form__forgot-password" to="/forgot-password">
                                 Mot de passe oublié ?
-                            </a>
+                            </Link>
                         </div>
 
                         <input


### PR DESCRIPTION
This pull request includes a small but important change to the `Login` component in `src/components/Auth/Login.jsx`. The change replaces an `<a>` tag with a `<Link>` component from React Router to properly handle navigation to the "Forgot Password" page.

* [`src/components/Auth/Login.jsx`](diffhunk://#diff-47d5cd2ab393ea7e10080b48b0499896efd88c1963577d7a53c4873c94c4abeeL55-R57): Replaced the `<a>` tag with a `<Link>` component and updated the `href` attribute to `to="/forgot-password"` for better routing and navigation.