### PR TITLE
fix: change input type from text to email in ForgotPassword component

### DIFF
--- a/src/components/Auth/ForgotPassword.jsx
+++ b/src/components/Auth/ForgotPassword.jsx
@@ -38,7 +38,7 @@ function ForgotPassword() {
                     <div className="form__group form__group-mb">
                         <label htmlFor="email">Adresse email</label>
                         <input
-                            type="text"
+                            type="email"
                             id="email"
                             className="form__control"
                             value={email}


### PR DESCRIPTION
This pull request includes a small but important change to the `ForgotPassword` component to improve form validation and user experience.

* [`src/components/Auth/ForgotPassword.jsx`](diffhunk://#diff-b8ab76de8069874ed672c8e13518daac01bf2b2ad7a53ab16331b95b1b2367f8L41-R41): Changed the input type for the email field from `text` to `email` to ensure proper email validation and accessibility.