### PR TITLE
fix: add media query for max-height to adjust illustration width

### DIFF
--- a/src/assets/css/modules/_hero.scss
+++ b/src/assets/css/modules/_hero.scss
@@ -30,6 +30,10 @@
         max-width: 660px;
         aspect-ratio: 1 / 1;
 
+        @media screen and (max-height: 800px) {
+            max-width: 560px;
+        }
+
         @media screen and (max-width: 900px) {
             display: none;
         }


### PR DESCRIPTION
This pull request introduces a responsive design improvement to the `_hero.scss` file by adjusting the `max-width` of elements for screens with a height of 800px or less.

* **Responsive design improvement**:
  * [`src/assets/css/modules/_hero.scss`](diffhunk://#diff-e80c5d748e414d1474027ef1de58979f0f2e3d8e4d38a4467667da13eb7898eeR33-R36): Added a media query to reduce the `max-width` to 560px for screens with a maximum height of 800px. This ensures better visual adaptability on shorter screens.