### PR TITLE
fix: remove unnecessary margin class from form group

### DIFF
--- a/src/components/Auth/ForgotPassword.jsx
+++ b/src/components/Auth/ForgotPassword.jsx
@@ -35,7 +35,7 @@ function ForgotPassword() {
                 {error && <p>{error}</p>}
 
                 <form onSubmit={handleSubmit}>
-                    <div className="form__group form__group-mb">
+                    <div className="form__group">
                         <label htmlFor="email">Adresse email</label>
                         <input
                             type="email"


### PR DESCRIPTION
This pull request includes a minor change to the `ForgotPassword` component in `src/components/Auth/ForgotPassword.jsx`. The change removes an unused CSS class (`form__group-mb`) from the `div` element wrapping the email input field.