### PR TITLE
fix: improve form responsiveness by replacing vh with dvh

### DIFF
--- a/src/assets/css/modules/_form.scss
+++ b/src/assets/css/modules/_form.scss
@@ -9,7 +9,7 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        min-height: 100vh;
+        min-height: 100dvh;
     }
 
     &__logo {


### PR DESCRIPTION
## Summary
This PR updates the form layout by replacing `vh` units with `dvh` units to improve responsiveness, especially on mobile devices.

## Why this change?
Using `dvh` provides better handling of dynamic viewport heights, avoiding layout issues caused by mobile browser UI changes.