### PR TITLE
fix: add font-family to button and unify font size for related elements

### DIFF
--- a/src/assets/css/modules/_form.scss
+++ b/src/assets/css/modules/_form.scss
@@ -77,6 +77,7 @@
         color: #fff;
         background-color: colors.$color-primary;
 
+        font-family: inherit;
         font-weight: 500;
 
         padding: .81rem 1rem;
@@ -111,5 +112,9 @@
 
     &__forgot-password {
         color: colors.$color-special-hover;
+    }
+
+    &__subtitle, &__group label, &__forgot-password, &__infos, &__button {
+        font-size: .875rem;
     }
 }


### PR DESCRIPTION
This pull request includes minor styling updates to the `_form.scss` file, focusing on font consistency and text size adjustments.

Styling updates:

* Added `font-family: inherit;` to ensure consistent font inheritance for form elements. (`src/assets/css/modules/_form.scss`, [src/assets/css/modules/_form.scssR80](diffhunk://#diff-e6353d626c25fe1c0c1c7e0a5daddead1185caed32f103cdee655e857fdb750eR80))
* Standardized font size to `.875rem` for several form-related elements, including `&__subtitle`, `&__group label`, `&__forgot-password`, `&__infos`, and `&__button`. (`src/assets/css/modules/_form.scss`, [src/assets/css/modules/_form.scssR116-R119](diffhunk://#diff-e6353d626c25fe1c0c1c7e0a5daddead1185caed32f103cdee655e857fdb750eR116-R119))