### PR TITLE
feat: prevent sending empty messages in PartyChat

### DIFF
--- a/src/components/Games/PartyChat.jsx
+++ b/src/components/Games/PartyChat.jsx
@@ -105,6 +105,8 @@ function PartyChat() {
     }
 
     const handleSendMessage = () => {
+        if (!message.trim()) return; // Prevent sending empty messages
+        
         console.log("Sending message", message);
         socket.emit("sendMessage", { message });
         setMessage("");


### PR DESCRIPTION
This pull request includes a small but important change to the `PartyChat` component to improve user experience by preventing the sending of empty messages.

* [`src/components/Games/PartyChat.jsx`](diffhunk://#diff-d3708f89b0e6badffb6350e9d478fdc91893a705c292842e2de2a75ddc487cc9R108-R109): Added a check in the `handleSendMessage` function to ensure that empty or whitespace-only messages are not sent.