### PR TITLE
fix: add border-radius to form content for consistent styling

### DIFF
--- a/src/assets/css/modules/_form.scss
+++ b/src/assets/css/modules/_form.scss
@@ -34,6 +34,8 @@
     &__content {
         background-color: #111827;
         padding: 1.5rem;
+
+        border-radius: 6px;
     }
 
     &__group {


### PR DESCRIPTION
This pull request includes a minor update to the `src/assets/css/modules/_form.scss` file. The change adds a border radius to the `&__content` class for improved styling.

Styling updates:

* [`src/assets/css/modules/_form.scss`](diffhunk://#diff-e6353d626c25fe1c0c1c7e0a5daddead1185caed32f103cdee655e857fdb750eR37-R38): Added a `border-radius` property with a value of `6px` to the `&__content` class for rounded corners.