### PR TITLE
chore(cd): add documentation build step to deploy workflow

### DIFF
--- a/.github/workflows/nodejs-ci-cd.yml
+++ b/.github/workflows/nodejs-ci-cd.yml
@@ -56,3 +56,4 @@ jobs:
             git pull origin main
             npm install
             npm run build
+            npm run docs:build


### PR DESCRIPTION
This pull request includes a small but important update to the Node.js CI/CD workflow. The change ensures that documentation is built as part of the CI/CD pipeline.

* [`.github/workflows/nodejs-ci-cd.yml`](diffhunk://#diff-9fff1086794eb54ee1906723dd519ddc0ca07e381dd89bba43ba65209faa9b27R59): Added the `npm run docs:build` command to the `jobs:` section to generate documentation during the build process.