### PR TITLE
feat: update error messages to French in authentication components

### DIFF
--- a/src/components/Auth/ForgotPassword.jsx
+++ b/src/components/Auth/ForgotPassword.jsx
@@ -14,7 +14,7 @@ function ForgotPassword() {
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
             await sleep(1000);
 
-            throw new Error("Invalid email");
+            throw new Error("Adresse e-mail invalide.");
             //navigate("/login");
         } catch (err) {
             setError(err.message);

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -39,7 +39,7 @@ export const AuthProvider = ({ children }) => {
             setUser({ token: data.token });
             localStorage.setItem("token", data.token);
         } else {
-            throw new Error("Login failed. Please check your credentials.");
+            throw new Error("Échec de la connexion. Veuillez vérifier vos identifiants.");
         }
     };
 
@@ -53,7 +53,7 @@ export const AuthProvider = ({ children }) => {
             },
         );
         if (!response.ok) {
-            throw new Error("Registration failed. Please try again.");
+            throw new Error("Échec de l’inscription. Veuillez réessayer.");
         }
     };
 


### PR DESCRIPTION
This pull request focuses on improving the user experience by localizing error messages in the authentication flow. The changes replace English error messages with their French equivalents in both the `ForgotPassword` component and the `AuthContext` context.

### Localization of error messages:

* [`src/components/Auth/ForgotPassword.jsx`](diffhunk://#diff-b8ab76de8069874ed672c8e13518daac01bf2b2ad7a53ab16331b95b1b2367f8L17-R17): Updated the error message thrown during the password recovery process from "Invalid email" to "Adresse e-mail invalide."
* `src/context/AuthContext.jsx`: 
  - Replaced the login failure error message "Login failed. Please check your credentials." with "Échec de la connexion. Veuillez vérifier vos identifiants."
  - Replaced the registration failure error message "Registration failed. Please try again." with "Échec de l’inscription. Veuillez réessayer."