### PR TITLE
feat: add rate limit error handling for login and registration

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -34,6 +34,10 @@ export const AuthProvider = ({ children }) => {
             },
         );
 
+        if (response.status === 429) {
+            throw new Error("Trop de tentatives de connexion. Veuillez réessayer plus tard.");
+        }
+
         const data = await response.json();
         if (data.token) {
             setUser({ token: data.token });
@@ -52,6 +56,11 @@ export const AuthProvider = ({ children }) => {
                 body: JSON.stringify({ username, password }),
             },
         );
+        
+        if (response.status === 429) {
+            throw new Error("Trop de tentatives d’inscription. Veuillez réessayer plus tard.");
+        }
+
         if (!response.ok) {
             throw new Error("Échec de l’inscription. Veuillez réessayer.");
         }


### PR DESCRIPTION
This pull request introduces a new error-handling mechanism in the `AuthProvider` component to manage rate-limiting scenarios. Specifically, it adds checks for HTTP status code `429` (Too Many Requests) and throws an appropriate error message when this condition is encountered.

Error handling for rate-limiting:

* [`src/context/AuthContext.jsx`](diffhunk://#diff-98a1f45af2dcd59433d60d3261a2df5de9d187164cbed4b1a148883b33b823daR37-R40): Added a check for `response.status === 429` in both the login and registration logic. If the status code matches, an error is thrown with the message "Trop de tentatives de connexion. Veuillez réessayer plus tard." [[1]](diffhunk://#diff-98a1f45af2dcd59433d60d3261a2df5de9d187164cbed4b1a148883b33b823daR37-R40) [[2]](diffhunk://#diff-98a1f45af2dcd59433d60d3261a2df5de9d187164cbed4b1a148883b33b823daR59-R63)