### PR TITLE
feat: display party host username in Parties and PartyChat components

### DIFF
--- a/src/components/Games/Parties.jsx
+++ b/src/components/Games/Parties.jsx
@@ -86,7 +86,7 @@ function Parties() {
                             onClick={() => handleSelectParty(party)}
                         >
                             {party.name} - {party.lang} - {party.style} -{" "}
-                            {party.maxPlayers} players max
+                            {party.maxPlayers} players max - Host: {party.host?.username}
                         </li>
                     ))}
                 </ul>

--- a/src/components/Games/PartyChat.jsx
+++ b/src/components/Games/PartyChat.jsx
@@ -116,7 +116,7 @@ function PartyChat() {
         <div>
             {party ? (
                 <>
-                    <h2>Chat for {party.name}</h2>
+                    <h2>Chat for {party.name} - Host: {party.host?.username}</h2>
                     <div>
                         <h3>Players in the Party</h3>
                         <ul>


### PR DESCRIPTION
This pull request enhances the user interface of the `Parties` and `PartyChat` components by including the party host's username in relevant displays. This change improves clarity for users by providing more context about the party's host.

UI improvements for party-related components:

* [`src/components/Games/Parties.jsx`](diffhunk://#diff-cdc4390e7a2fec87b44628ce0cd86434b3161d9af442eea841178774bba936cfL89-R89): Updated the party list to include the host's username alongside the party details.
* [`src/components/Games/PartyChat.jsx`](diffhunk://#diff-d3708f89b0e6badffb6350e9d478fdc91893a705c292842e2de2a75ddc487cc9L119-R119): Modified the chat header to display the host's username in addition to the party name.