### PR TITLE
fix: replace anchor tags with Link components for navigation in Hero and Promo

### DIFF
--- a/src/components/UI/Hero.jsx
+++ b/src/components/UI/Hero.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 function Hero() {
     return (
         <div className="hero">
@@ -13,8 +15,8 @@ function Hero() {
                     </div>
 
                     <div className="hero__infos-ctas">
-                        <a href="#" className="hero__infos-cta hero__infos-cta-start">Commencer</a>
-                        <a href="#" className="hero__infos-cta hero__infos-cta-explore">Explorer les jeux</a>
+                        <Link to="/register" className="hero__infos-cta hero__infos-cta-start">Commencer</Link>
+                        <Link to="/games" className="hero__infos-cta hero__infos-cta-explore">Explorer les jeux</Link>
                     </div>
                 </div>
 

--- a/src/components/UI/Promo.jsx
+++ b/src/components/UI/Promo.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 function Promo() {
     return (
         <div className="promo">
@@ -10,18 +12,18 @@ function Promo() {
                     discutent et jouent ensemble sur Disgame.
                 </div>
                 <div className="promo__content-ctas">
-                    <a
-                        href="#"
+                    <Link
+                        to="/register"
                         className="promo__content-cta promo__content-cta-start"
                     >
                         Créer un compte gratuit
-                    </a>
-                    <a
-                        href="#"
+                    </Link>
+                    <Link
+                        to="/games"
                         className="promo__content-cta promo__content-cta-explore"
                     >
                         Explorer les jeux
-                    </a>
+                    </Link>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This pull request updates the `Hero` and `Promo` components to replace `<a>` tags with React Router's `<Link>` component for better client-side navigation. The changes ensure proper routing within the application.

### Updates to `Hero` component:

* Replaced `<a>` tags with `<Link>` components for the "Commencer" and "Explorer les jeux" buttons, linking to `/register` and `/games` respectively (`src/components/UI/Hero.jsx`, [src/components/UI/Hero.jsxL16-R19](diffhunk://#diff-c33b5ea986592857b7eb2d9acc99aaf3abd8f09b3adf279d21aa0a4851da7bf1L16-R19)).
* Added the `Link` import from `react-router-dom` (`src/components/UI/Hero.jsx`, [src/components/UI/Hero.jsxR1-R2](diffhunk://#diff-c33b5ea986592857b7eb2d9acc99aaf3abd8f09b3adf279d21aa0a4851da7bf1R1-R2)).

### Updates to `Promo` component:

* Replaced `<a>` tags with `<Link>` components for the "Créer un compte gratuit" and "Explorer les jeux" buttons, linking to `/register` and `/games` respectively (`src/components/UI/Promo.jsx`, [src/components/UI/Promo.jsxL13-R26](diffhunk://#diff-fd1671d434b8d247f917251f330f7bebc29db3a84d02ec208c64e8d17a0b45aaL13-R26)).
* Added the `Link` import from `react-router-dom` (`src/components/UI/Promo.jsx`, [src/components/UI/Promo.jsxR1-R2](diffhunk://#diff-fd1671d434b8d247f917251f330f7bebc29db3a84d02ec208c64e8d17a0b45aaR1-R2)).