### PR TITLE
docs: update getting-started guide with corrected server environment setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,14 +43,14 @@ Before you begin, ensure you have the following installed:
     JWT_SECRET=your_jwt_secret # Secret key used to sign JSON Web Tokens
 
     # Database connection variables
-    DB_HOST=
-    DB_PORT=
-    DB_USER=
-    DB_PASS=
-    DB_NAME=
+    DB_HOST=localhost # The hostname of the database server
+    DB_PORT=3306 # The port number for the database (default for MySQL is 3306)
+    DB_USER=root # The username for the database
+    DB_PASS=your_database_password # The password for the database user
+    DB_NAME=disgame # The name of the database
     ```
 
-    > **Note**: By default, if the `NODE_ENV` variable is not set to `production`, the database used will be SQLite. In this case, you do not need to fill in the `DB_` variables.
+    > **Note**: Ensure that the database connection variables (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME`) are correctly configured for your MySQL database.
 
 6. Start the server:
     ```bash


### PR DESCRIPTION
This pull request updates the `docs/getting-started.md` file to clarify the configuration of database connection variables and improve the instructions for setting up the environment.

Documentation improvements:

* [`docs/getting-started.md`](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L46-R53): Updated the database connection variables (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME`) with example values and added detailed comments to clarify their purpose. Revised the note to emphasize proper configuration for MySQL databases.