### PR TITLE
fix: update player profile links in PartyChat to reference correct player IDs

### DIFF
--- a/src/assets/css/modules/_navbar.scss
+++ b/src/assets/css/modules/_navbar.scss
@@ -57,6 +57,10 @@
         display: flex;
         align-items: center;
         gap: 3rem;
+
+        @media screen and (max-width: 547px) {
+            display: none;
+        }
     }
 
     &__logo {

--- a/src/components/Games/PartyChat.jsx
+++ b/src/components/Games/PartyChat.jsx
@@ -354,13 +354,13 @@ function PartyChatUI() {
                                         className="party-chat__sidebar-player"
                                         key={player.id}
                                     >
-                                        <Link to={`/profile/${party.host?.id}`} className="party-chat__sidebar-player-picture">
+                                        <Link to={`/profile/${player.id}`} className="party-chat__sidebar-player-picture">
                                             <img
                                                 src={`https://ui-avatars.com/api/?background=random&name=${player.username}&size=50`}
                                                 alt="Player's picture"
                                             />
                                         </Link>
-                                        <Link to={`/profile/${party.host?.id}`} className="party-chat__sidebar-player-name">
+                                        <Link to={`/profile/${player.id}`} className="party-chat__sidebar-player-name">
                                             {player.username}
                                         </Link>
                                     </div>


### PR DESCRIPTION
This pull request includes a fix to the `PartyChatUI` function in `src/components/Games/PartyChat.jsx`. The change ensures that player-specific links are correctly generated for each player in the party chat sidebar instead of mistakenly using the party host's ID.

Key update:

* [`src/components/Games/PartyChat.jsx`](diffhunk://#diff-d3708f89b0e6badffb6350e9d478fdc91893a705c292842e2de2a75ddc487cc9L357-R363): Updated the `Link` elements for player pictures and names to use `player.id` instead of `party.host?.id`, ensuring the links point to the correct player's profile.